### PR TITLE
Fix Docker development stack startup issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,26 @@ Loop process responsible for reading temperature and himidity data, then send th
 - Docker
 ---
 
+## Docker development environment
+
+The services defined in `infra/docker-compose.yml` can be started with `docker compose` for local development. By default the Vite web UI is exposed on host port `5173`, but you can override that value by setting the `WEB_PORT` environment variable when launching the stack, for example:
+
+```bash
+WEB_PORT=5174 docker compose -f infra/docker-compose.yml up web
+```
+
+```powershell
+$Env:WEB_PORT = '5174'
+docker compose -f infra/docker-compose.yml up web
+```
+
+If you prefer, you can also create an `.env` file alongside `infra/docker-compose.yml` containing `WEB_PORT=5174` so Compose picks up the override automatically.
+
+> **Note for Windows users:** use a port that is not listed as excluded by `netsh interface ipv4 show excludedportrange protocol=tcp` to avoid conflicts with the operating system’s reserved ranges.
+
+
+---
+
 ## Project Structure
 
 ```

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -15,4 +15,11 @@ services:
       - MQTT_BROKER=mosquitto
     depends_on: [postgres, mosquitto]
     ports: ["8000:8000"]
+  web:
+    image: node:20
+    working_dir: /app
+    volumes: ["../web:/app"]
+    command: ["sh", "-c", "npm install && npm run dev -- --host 0.0.0.0 --port ${WEB_PORT:-5173}"]
+    environment: ["WEB_PORT=${WEB_PORT:-5173}"]
+    ports: ["${WEB_PORT:-5173}:${WEB_PORT:-5173}"]
 volumes: { pg: {} }

--- a/infra/mosquitto.conf
+++ b/infra/mosquitto.conf
@@ -1,0 +1,2 @@
+listener 1883 0.0.0.0
+allow_anonymous true


### PR DESCRIPTION
## Summary
- keep the web service port mapping aligned with `WEB_PORT` and install dependencies before launching the dev server
- add a default Mosquitto configuration so the volume mount succeeds
- document PowerShell and `.env` options for overriding `WEB_PORT`

## Testing
- not run (docker not available in the CI environment)


------
https://chatgpt.com/codex/tasks/task_e_68e07cf4f0c48333b1148669a7cbb61e